### PR TITLE
Fix handling of undocumented exceptions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-docletVersion=0.1.0
+docletVersion=0.2.0
 schemaVersion=0.1.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/sample/src/main/java/org/example/Sample.java
+++ b/sample/src/main/java/org/example/Sample.java
@@ -1,5 +1,10 @@
 package org.example;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
 /**
  * Sample application
  * <p>This application exists just to test the various features of the xmldoclet.</p>
@@ -11,4 +16,30 @@ public class Sample {
         SampleRuntime runtime = new SampleRuntime();
         runtime.run();
     }
+
+    public void throwsOne() throws IOException {
+        try {
+            File f = new File("/tmp/not-likely");
+            FileInputStream fis = new FileInputStream(f);
+        } catch (FileNotFoundException ex) {
+            throw ex;
+        }
+    }
+
+    /**
+     * Throws two exceptions, but only documents one.
+     * @throws IOException if the file isn't found
+     */
+    public void throwsTwo() throws IOException, IllegalArgumentException {
+        try {
+            File f = new File("/tmp/not-likely");
+            FileInputStream fis = new FileInputStream(f);
+            if (fis == null) {
+                throw new IllegalArgumentException("Can't have a null file");
+            }
+        } catch (FileNotFoundException ex) {
+            throw ex;
+        }
+    }
+
 }

--- a/sample/src/main/java/org/example/TestClass.java
+++ b/sample/src/main/java/org/example/TestClass.java
@@ -12,6 +12,8 @@ import java.util.*;
  */
 
 public class TestClass implements CharacterSet {
+    public static final TestClass CONSTANTVALUE = new TestClass();
+
     /** The tick! With {@value}*/
     protected final int spoon = 17;
 
@@ -43,7 +45,6 @@ public class TestClass implements CharacterSet {
     public String getCanonicalName() {
         return "UTF-16";
     }
-
 
     public static final int NONBMP_MIN = 0x10000;
     public static final int NONBMP_MAX = 0x10FFFF;


### PR DESCRIPTION
The doclet now produces a `<throws>` element for all exceptions thrown by a method, not just the documented exceptions. An undocumented exception has no `body`.