### PR TITLE
Support more information about superclasses and interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Notes:
   `(char) 0x…` is used for the value instead of the character’s
   literal value.
 
-
 ## Feedback welcome
 
 Much of the output is the result of experimentation and exploring the

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-docletVersion=0.2.0
-schemaVersion=0.1.0
+docletVersion=0.3.0
+schemaVersion=0.3.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlTypeElement.java
+++ b/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlTypeElement.java
@@ -1,16 +1,15 @@
 package com.saxonica.xmldoclet.scanners;
 
-import com.saxonica.xmldoclet.utils.TypeUtils;
 import com.saxonica.xmldoclet.builder.XmlProcessor;
+import com.saxonica.xmldoclet.utils.TypeUtils;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.doctree.DocTree;
 
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public abstract class XmlTypeElement extends XmlScanner {
     private final TypeElement element;
@@ -23,7 +22,9 @@ public abstract class XmlTypeElement extends XmlScanner {
     public abstract String typeName();
 
     public void scan(DocTree tree) {
-        Map<String,String> attr = new HashMap<>();
+        String s = element.getQualifiedName().toString();
+
+        Map<String, String> attr = new HashMap<>();
         attr.put("fullname", element.getQualifiedName().toString());
         attr.put("package", element.getEnclosingElement().toString());
         attr.put("type", element.getSimpleName().toString());
@@ -35,9 +36,9 @@ public abstract class XmlTypeElement extends XmlScanner {
         builder.startElement(typeName(), attr);
 
         if (element.getSuperclass() instanceof DeclaredType) {
-            builder.startElement("superclass");
-            TypeUtils.xmlType(builder, "type", element.getSuperclass());
-            builder.endElement("superclass");
+            Implemented impl = new Implemented();
+            updateImplemented(element, impl);
+            showSuperclass(element, (DeclaredType) element.getSuperclass(), impl);
         }
 
         if (!element.getInterfaces().isEmpty()) {
@@ -69,5 +70,127 @@ public abstract class XmlTypeElement extends XmlScanner {
         builder.xmlscan(element.getEnclosedElements());
 
         builder.endElement(typeName());
+    }
+
+    private void showSuperclass(TypeElement element, DeclaredType superclass, Implemented impl) {
+        builder.startElement("superclass");
+        TypeUtils.xmlType(builder, "type", element.getSuperclass());
+
+        List<? extends Element> enclosed = superclass.asElement().getEnclosedElements();
+
+        List<Element> inherited = new ArrayList<>();
+        for (Element elem : enclosed) {
+            String name = elem.toString();
+            if (elem.getModifiers().contains(Modifier.PUBLIC) || elem.getModifiers().contains(Modifier.PROTECTED)) {
+                if (elem.getKind() == ElementKind.FIELD) {
+                    if (!impl.fields.contains(name)) {
+                        impl.fields.add(name);
+                        inherited.add(elem);
+                    }
+                }
+                if (elem.getKind() == ElementKind.METHOD) {
+                    if (!impl.methods.contains(name)) {
+                        impl.methods.add(name);
+                        inherited.add(elem);
+                    }
+                }
+            }
+        }
+
+        if (!inherited.isEmpty()) {
+            builder.startElement("inherited");
+            for (Element elem : inherited) {
+                Map<String, String> amap = new HashMap<>();
+                amap.put("name", elem.getSimpleName().toString());
+                if (elem.getKind() == ElementKind.FIELD) {
+                    builder.startElement("field", amap);
+                    builder.endElement("field");
+                } else {
+                    builder.startElement("method", amap);
+                    builder.endElement("method");
+                }
+            }
+            builder.endElement("inherited");
+        }
+
+        Element selem = superclass.asElement();
+        if (selem instanceof TypeElement) {
+            TypeElement setype = (TypeElement) selem;
+            TypeMirror sstype = setype.getSuperclass();
+
+            showInterfaces(setype, impl);
+
+/*
+
+            if (!setype.getInterfaces().isEmpty()) {
+                builder.startElement("interfaces");
+                for (TypeMirror tm : setype.getInterfaces()) {
+                    if (tm.getKind() == TypeKind.DECLARED) {
+                        DeclaredType dtm = (DeclaredType) tm;
+                        System.err.println(dtm);
+                    }
+                    TypeUtils.xmlType(builder, "interfaceref", tm);
+                }
+                builder.endElement("interfaces");
+            }
+ */
+
+            if (sstype.getKind() == TypeKind.DECLARED) {
+                showSuperclass(setype, (DeclaredType) sstype, impl);
+            }
+
+        }
+
+        builder.endElement("superclass");
+    }
+
+    private void showInterfaces(TypeElement element, Implemented impl) {
+        if (element.getInterfaces().isEmpty()) {
+            return;
+        }
+
+        for (TypeMirror tm : element.getInterfaces()) {
+            if (tm.getKind() == TypeKind.DECLARED) {
+                TypeElement ttm = (TypeElement) ((DeclaredType) tm).asElement();
+                Map<String, String> amap = new HashMap<>();
+                amap.put("fullname", ttm.toString());
+                amap.put("name", ttm.getSimpleName().toString());
+                if (ttm.toString().contains(".")) {
+                    amap.put("package", ttm.toString().substring(0, ttm.toString().lastIndexOf(".")));
+                }
+
+                builder.startElement("interface", amap);
+
+                for (Element celem : ttm.getEnclosedElements()) {
+                    if (celem.getKind() == ElementKind.FIELD) {
+                        amap = new HashMap<>();
+                        amap.put("name", celem.getSimpleName().toString());
+                        builder.startElement("field", amap);
+                        builder.endElement("field");
+                    }
+                }
+
+                showInterfaces(ttm, impl);
+                builder.endElement("interface");
+            }
+        }
+    }
+
+    private void updateImplemented(TypeElement element, Implemented impl) {
+        for (Element elem : element.getEnclosedElements()) {
+            if (elem.getModifiers().contains(Modifier.PUBLIC) || elem.getModifiers().contains(Modifier.PROTECTED)) {
+                if (elem.getKind() == ElementKind.FIELD) {
+                    impl.fields.add(elem.toString());
+                }
+                if (elem.getKind() == ElementKind.METHOD) {
+                    impl.methods.add(elem.toString());
+                }
+            }
+        }
+    }
+
+    private static class Implemented {
+        public final Set<String> fields = new HashSet<>();
+        public final Set<String> methods = new HashSet<>();
     }
 }

--- a/xmldoclet/src/main/resources/doclet.rnc
+++ b/xmldoclet/src/main/resources/doclet.rnc
@@ -142,7 +142,36 @@ constant =
 
 superclass =
     element superclass {
-        typeDecl
+        typeDecl,
+        inherited?,
+        iinterface*,
+        superclass?
+    }
+
+inherited =
+    element inherited {
+        (ifield | imethod)*
+    }
+
+ifield =
+    element field {
+        attribute name { text },
+        empty
+    }
+
+imethod =
+    element method {
+        attribute name { text },
+        empty
+    }
+
+iinterface =
+    element interface {
+        attribute package { text }?,
+        attribute fullname { text },
+        attribute name { text },
+        ifield*,
+        iinterface*
     }
 
 interfaces =

--- a/xmldoclet/src/test/java/com/saxonica/xmldoclet/DocletTest.java
+++ b/xmldoclet/src/test/java/com/saxonica/xmldoclet/DocletTest.java
@@ -1,5 +1,6 @@
 package com.saxonica.xmldoclet;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.tools.DocumentationTool;
@@ -34,4 +35,20 @@ public class DocletTest {
         DocumentationTool docTool = ToolProvider.getSystemDocumentationTool();
         docTool.run(System.in, System.out, System.err, docletArgs);
     }
+
+    // This test is only meaningful locally
+    @Disabled
+    public void saxonSample() {
+        String[] docletArgs = new String[]{
+                "-doclet", XmlDoclet.class.getName(),
+                "-docletpath", "build/classes/",
+                "-classpath", "/Users/ndw/.m2/repository/jline/jline/2.14.6/jline-2.14.6.jar:/Volumes/Saxonica/src/saxonica/saxondev/build/releases/eej/lib/xmlresolver-5.2.2.jar",
+                "-sourcepath", "../../saxondev/src/main/java",
+                "net.sf.saxon.serialize", "net.sf.saxon.event"
+        };
+
+        DocumentationTool docTool = ToolProvider.getSystemDocumentationTool();
+        docTool.run(System.in, System.out, System.err, docletArgs);
+    }
+
 }


### PR DESCRIPTION
The main change in this update is the addition of more detail in the `superclass` element for classes. The `superclass` now enumerates fields and methods that are inherited and interfaces that are implemented (including fields declared in those interfaces).

The goal is to provide enough detail to produce output that's as rich as the standards JavaDoc HTML output without bloating the output too much. There's an argument to be made for a more normalized approach where there's exactly one copy of each class, superclass, interface, etc. and pointers to those. On the one hand, that would reduce the size of the output, but on the other, it would be more complicated to use the output.

If this doesn't seem like a good compromise, suggestions for improvements are always welcome.