### PR TITLE
Bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-docletVersion=0.3.0
-schemaVersion=0.3.0
+docletVersion=0.4.0
+schemaVersion=0.4.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/xmldoclet/src/main/java/com/saxonica/xmldoclet/builder/XmlBuilder.java
+++ b/xmldoclet/src/main/java/com/saxonica/xmldoclet/builder/XmlBuilder.java
@@ -308,8 +308,13 @@ public class XmlBuilder extends MarkupBuilder {
                 break;
             case PARAM:
             case RETURN:
-            case DEPRECATED:
                 // Handled in enclosing class
+                break;
+            case DEPRECATED:
+                DeprecatedTree depTree = (DeprecatedTree) tree;
+                startElement(depTree.getTagName());
+                html(depTree.getBody());
+                endElement(depTree.getTagName());
                 break;
             case CODE:
             case LITERAL:

--- a/xmldoclet/src/main/java/com/saxonica/xmldoclet/builder/XmlProcessor.java
+++ b/xmldoclet/src/main/java/com/saxonica/xmldoclet/builder/XmlProcessor.java
@@ -158,7 +158,16 @@ public class XmlProcessor extends ElementScanner9<Void, XmlProcessor> {
         builder = new XmlBuilder(this);
         startDocument();
         for (Element element : elements) {
-            xmlscan(element);
+            if (element.getKind() == ElementKind.CLASS) {
+                TypeElement xelem = (TypeElement) element;
+                if (xelem.getNestingKind() == NestingKind.TOP_LEVEL) {
+                    // Don't output nested, inner classes at the top level. They'll automatically
+                    // be output in the surrounding class
+                    xmlscan(element);
+                }
+            } else {
+                xmlscan(element);
+            }
         }
         endDocument();
 

--- a/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlTypeElement.java
+++ b/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlTypeElement.java
@@ -55,6 +55,9 @@ public abstract class XmlTypeElement extends XmlScanner {
                 attr.clear();
                 attr.put("name", tp.toString());
                 builder.startElement("typeparam", attr);
+                for (TypeMirror bound : tp.getBounds()) {
+                    TypeUtils.xmlType(builder, "type", bound);
+                }
                 builder.endElement("typeparam");
             }
             builder.endElement("typeparams");

--- a/xmldoclet/src/test/java/com/saxonica/xmldoclet/DocletTest.java
+++ b/xmldoclet/src/test/java/com/saxonica/xmldoclet/DocletTest.java
@@ -41,10 +41,11 @@ public class DocletTest {
     public void saxonSample() {
         String[] docletArgs = new String[]{
                 "-doclet", XmlDoclet.class.getName(),
+                "-private",
                 "-docletpath", "build/classes/",
                 "-classpath", "/Users/ndw/.m2/repository/jline/jline/2.14.6/jline-2.14.6.jar:/Volumes/Saxonica/src/saxonica/saxondev/build/releases/eej/lib/xmlresolver-5.2.2.jar",
                 "-sourcepath", "../../saxondev/src/main/java",
-                "net.sf.saxon.serialize", "net.sf.saxon.event"
+                "net.sf.saxon.trans"
         };
 
         DocumentationTool docTool = ToolProvider.getSystemDocumentationTool();


### PR DESCRIPTION
1. Attempt to cleanup how `@throws` and `throws` are handled so that there are no duplicates. This is slightly complicated because `@throws` can be a simple name or a fully qualified name.
2. Don't output nested classes at the top-level. They'll be inside the top-level classes that they nest within.
3. Include subtype information about parameterized types.
4. Output XML elements for the `@deprecated` tag.