### PR TITLE
Method fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,18 @@ incomplete or incorrect, please [open an issue](https://github.com/Saxonica/xmld
 
 ## Change log
 
+* **0.6.0** Improved handling of method names and inheritance
+  
+  Changed the “name” of methods to include the parameter types. (i.e., `foo(int)`
+  instead of `foo`). This allows them to be distinguished.
+  
+  Fixed a bug where the methods inherited from interfaces were not shown.
+  
+  Fixed a bug in computing visibility. Previously, the code looked for an explicit
+  ~public~ or ~protected~ modifier. Now it *excludes* things explicitly marked ~private~.
+  
+  Experimentally removed ~java.lang.Object~ as a supertype in the generated XML.
+
+The previous version looked for methods and fields marked as public or protected, but that's not the same thing!
+
 * **0.5.0** String constants now use “backslash-U” escapes for non-ASCII characters.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-docletVersion=0.5.0
-schemaVersion=0.5.0
+xdocletVersion=0.6.0
+schemaVersion=0.6.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-xdocletVersion=0.6.0
+docletVersion=0.6.0
 schemaVersion=0.6.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/sample/src/main/java/org/example/AbstractClass.java
+++ b/sample/src/main/java/org/example/AbstractClass.java
@@ -1,4 +1,13 @@
 package org.example;
 
 abstract public class AbstractClass implements TestInterface {
+    abstract void one(int value);
+    abstract void one(int value, int otherValue);
+    abstract void one(String value);
+    public void foo() {
+        System.err.println("impl in AbstractClass");
+    }
+    public void inAbsr() {
+        System.err.println("impl in AbstractClass");
+    }
 }

--- a/sample/src/main/java/org/example/AlternateImplementation.java
+++ b/sample/src/main/java/org/example/AlternateImplementation.java
@@ -1,0 +1,23 @@
+package org.example;
+
+public class AlternateImplementation extends Implementation {
+    @Override
+    void one(int value, int otherValue) {
+        System.err.println("alternate: " + value + ", " + otherValue);
+    }
+
+    @Override
+    void one(String value) {
+        // nop
+    }
+
+    @Override
+    public void foo() {
+        System.err.println("alternate foo");
+    }
+
+    @Override
+    public void baz() {
+        System.err.println("alternate baz");
+    }
+}

--- a/sample/src/main/java/org/example/AxisIterator.java
+++ b/sample/src/main/java/org/example/AxisIterator.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public interface AxisIterator extends SequenceIterator {
+    @Override
+    String next();
+}

--- a/sample/src/main/java/org/example/EmptyIterator.java
+++ b/sample/src/main/java/org/example/EmptyIterator.java
@@ -1,0 +1,17 @@
+package org.example;
+
+public class EmptyIterator implements SequenceIterator {
+    @Override
+    public Object next() {
+        return null;
+    }
+
+    private static class OfNodes extends EmptyIterator implements AxisIterator {
+
+        public final static OfNodes THE_INSTANCE = new OfNodes();
+        @Override
+        public String next() {
+            return null;
+        }
+    }
+}

--- a/sample/src/main/java/org/example/Implementation.java
+++ b/sample/src/main/java/org/example/Implementation.java
@@ -1,6 +1,6 @@
 package org.example;
 
-public class Implementation extends AbstractClass {
+public abstract class Implementation extends AbstractClass {
     @Override
     public void foo() {
         // nop
@@ -9,5 +9,19 @@ public class Implementation extends AbstractClass {
     @Override
     public void bar() {
         // nop
+    }
+
+    @Override
+    void one(int value) {
+        System.err.println("int: " + value);
+    }
+
+    @Override
+    void one(int value, int otherValue) {
+        System.err.println("int: " + value + ", " + otherValue);
+    }
+
+    void inImpl() {
+        System.err.println("In impl");
     }
 }

--- a/sample/src/main/java/org/example/IterImpl.java
+++ b/sample/src/main/java/org/example/IterImpl.java
@@ -1,0 +1,18 @@
+package org.example;
+
+public class IterImpl implements SequenceIterator {
+    @Override
+    public boolean hasNext() {
+        return false;
+    }
+
+    @Override
+    public Object next() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+        // nop
+    }
+}

--- a/sample/src/main/java/org/example/ParameterizedClass.java
+++ b/sample/src/main/java/org/example/ParameterizedClass.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class ParameterizedClass<T> {
+    private T[] _value;
+    public T get(int key) {
+        return _value[key];
+    }
+}

--- a/sample/src/main/java/org/example/SequenceIterator.java
+++ b/sample/src/main/java/org/example/SequenceIterator.java
@@ -1,0 +1,8 @@
+package org.example;
+
+import java.io.Closeable;
+
+public interface SequenceIterator extends Closeable  {
+    public Object next();
+    default void close() {}
+}

--- a/sample/src/main/java/org/example/TestClass.java
+++ b/sample/src/main/java/org/example/TestClass.java
@@ -5,6 +5,7 @@ import jdk.javadoc.doclet.Reporter;
 import net.sf.saxon.lib.Feature;
 import net.sf.saxon.serialize.charcode.CharacterSet;
 
+import java.lang.reflect.Parameter;
 import java.util.*;
 
 /**
@@ -13,11 +14,18 @@ import java.util.*;
 
 public class TestClass implements CharacterSet {
     public static final TestClass CONSTANTVALUE = new TestClass();
+    protected ParameterizedClass<String> stringParameterizedClass = new ParameterizedClass<>();
 
     /** The tick! With {@value}*/
     protected final int spoon = 17;
 
     private static final TestClass theInstance = new TestClass();
+
+    /**
+     * Constant indicating 1.0
+     */
+
+    public static final int XML10 = 10;
 
     /**
      * Private constructor to force the singular instance to be used

--- a/sample/src/main/java/org/example/TestInterface.java
+++ b/sample/src/main/java/org/example/TestInterface.java
@@ -12,4 +12,5 @@ public interface TestInterface {
      * <p>See also {@link #foo()}.</p>
      */
     void bar();
+    void baz();
 }

--- a/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlExecutableElement.java
+++ b/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlExecutableElement.java
@@ -25,7 +25,7 @@ public abstract class XmlExecutableElement extends XmlScanner {
 
         // Hack
         if (!"constructor".equals(typeName())) {
-            attr.put("name", element.getSimpleName().toString());
+            attr.put("name", element.toString());
         }
 
         Map<String,DeclaredType> thrownTypes = new HashMap<>();


### PR DESCRIPTION
1. Change method "name" references to include the argument types.
2. Show methods inherited from interfaces.
3. A method or field is suppressed only if it's marked private.

The previous version looked for methods and fields marked as public or protected, but that's not the same thing!