### PR TITLE
Rework how interfaces are displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ incomplete or incorrect, please [open an issue](https://github.com/Saxonica/xmld
 
 ## Change log
 
+* **0.7.0** Improved presentation of interfaces
+
+  Reworked the way interfaces are presented so that the methods inherited
+  from those interfaces (i.e., the methods not actually implemented on this class)
+  are shown.
+
 * **0.6.0** Improved handling of method names and inheritance
   
   Changed the “name” of methods to include the parameter types. (i.e., `foo(int)`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-docletVersion=0.6.0
-schemaVersion=0.6.0
+docletVersion=0.7.0
+schemaVersion=0.7.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/sample/src/main/java/org/example/Impl.java
+++ b/sample/src/main/java/org/example/Impl.java
@@ -1,0 +1,4 @@
+package org.example;
+
+abstract public class Impl implements InterfaceAB, InterfaceA {
+}

--- a/sample/src/main/java/org/example/ImplAB.java
+++ b/sample/src/main/java/org/example/ImplAB.java
@@ -1,0 +1,8 @@
+package org.example;
+
+abstract public class ImplAB implements InterfaceAB {
+    @Override
+    public void a() {
+        System.err.println("ImplAB implements a");
+    }
+}

--- a/sample/src/main/java/org/example/ImplABC.java
+++ b/sample/src/main/java/org/example/ImplABC.java
@@ -1,0 +1,13 @@
+package org.example;
+
+public class ImplABC extends ImplAB implements InterfaceABC {
+    @Override
+    public void b() {
+        System.err.println("ImplABC implements b");
+    }
+
+    @Override
+    public void c() {
+        System.err.println("ImplABC implements c");
+    }
+}

--- a/sample/src/main/java/org/example/InterfaceA.java
+++ b/sample/src/main/java/org/example/InterfaceA.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public interface InterfaceA {
+    void a();
+}

--- a/sample/src/main/java/org/example/InterfaceAB.java
+++ b/sample/src/main/java/org/example/InterfaceAB.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public interface InterfaceAB extends InterfaceA {
+    void b();
+}

--- a/sample/src/main/java/org/example/InterfaceABC.java
+++ b/sample/src/main/java/org/example/InterfaceABC.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public interface InterfaceABC extends InterfaceAB {
+    void c();
+}

--- a/sample/src/main/java/org/example/IterImpl.java
+++ b/sample/src/main/java/org/example/IterImpl.java
@@ -1,7 +1,6 @@
 package org.example;
 
 public class IterImpl implements SequenceIterator {
-    @Override
     public boolean hasNext() {
         return false;
     }


### PR DESCRIPTION
Show the chain of inherited interfaces and, for abstract classes, the inherited (i.e., unimplemented) methods.