### PR TITLE
Fix method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ incomplete or incorrect, please [open an issue](https://github.com/Saxonica/xmld
 
 ## Change log
 
+* **0.8.0** Fixed method names
+
+  Output the “simple” method name in the name attribute on method elements.
+  The full signature is also provided and the parameters and their types are available
+  from children.
+
 * **0.7.0** Improved presentation of interfaces
 
   Reworked the way interfaces are presented so that the methods inherited

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-docletVersion=0.7.0
-schemaVersion=0.7.0
+docletVersion=0.8.0
+schemaVersion=0.8.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/sample/src/main/java/org/example/Locale.java
+++ b/sample/src/main/java/org/example/Locale.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public class Locale {
+    // Not the java.util.Locale class
+}

--- a/sample/src/main/java/org/example/TestClass.java
+++ b/sample/src/main/java/org/example/TestClass.java
@@ -4,6 +4,7 @@ import jdk.javadoc.doclet.DocletEnvironment;
 import jdk.javadoc.doclet.Reporter;
 import net.sf.saxon.lib.Feature;
 import net.sf.saxon.serialize.charcode.CharacterSet;
+import java.util.Locale;
 
 import java.lang.reflect.Parameter;
 import java.util.*;
@@ -78,6 +79,9 @@ public class TestClass implements CharacterSet {
     }
 
     public void foo(Class<? extends Object> spoon) {
+    }
+
+    public void bar(Locale myLocal) {
 
     }
 

--- a/sample/src/main/java/org/example/packagea/ItemProcessor.java
+++ b/sample/src/main/java/org/example/packagea/ItemProcessor.java
@@ -1,0 +1,12 @@
+package org.example.packagea;
+
+import org.example.packageb.Item;
+
+/**
+ * This is a link to {@link Item}.
+ */
+public class ItemProcessor {
+    public ItemProcessor(Item item) {
+
+    }
+}

--- a/sample/src/main/java/org/example/packageb/Item.java
+++ b/sample/src/main/java/org/example/packageb/Item.java
@@ -1,0 +1,5 @@
+package org.example.packageb;
+
+public class Item {
+    // an item
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,6 @@
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+}
+
 rootProject.name = 'xmldoclet'
 include('xmldoclet', 'sample')

--- a/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlExecutableElement.java
+++ b/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlExecutableElement.java
@@ -25,7 +25,7 @@ public abstract class XmlExecutableElement extends XmlScanner {
 
         // Hack
         if (!"constructor".equals(typeName())) {
-            attr.put("name", element.toString());
+            attr.put("name", element.getSimpleName().toString());
         }
 
         Map<String,DeclaredType> thrownTypes = new HashMap<>();

--- a/xmldoclet/src/test/java/com/saxonica/xmldoclet/DocletTest.java
+++ b/xmldoclet/src/test/java/com/saxonica/xmldoclet/DocletTest.java
@@ -30,6 +30,8 @@ public class DocletTest {
                 "-docletpath", "build/classes/",
                 "-sourcepath", "../sample/src/main/java",
                 "org.example",
+                "org.example.packagea",
+                "org.example.packageb",
         };
 
         DocumentationTool docTool = ToolProvider.getSystemDocumentationTool();


### PR DESCRIPTION
The recent fix to output method parameters accidentally carried over to the name of the method on the `<method>` element. That's not necessary or helpful.