### PR TITLE
"Improve" the type equality test for method parameter types

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ incomplete or incorrect, please [open an issue](https://github.com/Saxonica/xmld
 
 ## Change log
 
+* **0.11.0** Improve type equality comparison when looking for overrides
+
+  The solution here is a fairly awful hack. Will have to come back to this and try to do better.
+
 * **0.10.0** Fix superclass interfaces; output information about type parameters
 
   Moved the interface information about a superclass into the superclass

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-docletVersion=0.10.0
-schemaVersion=0.10.0
+docletVersion=0.11.0
+schemaVersion=0.11.0
 docletTitle=XmlDoclet
 docletName=xmldoclet

--- a/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlExecutableElement.java
+++ b/xmldoclet/src/main/java/com/saxonica/xmldoclet/scanners/XmlExecutableElement.java
@@ -242,7 +242,8 @@ public abstract class XmlExecutableElement extends XmlScanner {
     }
 
     private boolean sameType(TypeMirror t1, TypeMirror t2) {
-        return t1.equals(t2);
+        // Cheap and cheerful test
+        return t1.toString().equals(t2.toString());
     }
 
 }


### PR DESCRIPTION
This is a terrible hack to improve issue #16 but it isn't a proper fix.

A proper fix is to recursively compare the types. I think that's going to be necessary to handle the case where there are subtype relationships.